### PR TITLE
Simplifying the initial setup/dev process

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ ___
 The following items must be installed on your dev machine with the exception of the MongoDB server. You just need a sever to be available for development.
 
 -  MongoDB database server <https://www.mongodb.com/download-center#community>
+  - Note that this project provides a [docker-compose](docker-compose.yml) file. With a docker engine installed, you can run `docker-compose up` to launch a MongoDB server exposed on it's default port, 27017.
 -  Node.js version 4.x or above <https://nodejs.org/en/> (Mac users see note below before installing node)
 -  Git Client <https://desktop.github.com/> or <https://git-scm.com/>
 -  Android Studio <https://developer.android.com/studio/index.html> and JDK 1.8 <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html> on Macs and Windows machines

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Applewood 
+# Applewood
 
 Applewood is a tasty flavor of The Smoke House Project <https://github.com/smokehouseproject>
 
@@ -57,7 +57,7 @@ ___
 6.  `npm install karma-cli -g`
 7.  `npm install` (Be patient - it may take awhile!)
 
-Next set configurations before running the prep command
+Next if you're not running MongoDB locally, set its host configuration  before running the prep command
 
 1. Determine the IP address of your MongoDB server
 2. Edit `server/config/config.dev.js` and set the following:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ ___
 6.  `npm install karma-cli -g`
 7.  `npm install` (Be patient - it may take awhile!)
 
-Next if you're not running MongoDB locally, set its host configuration  before running the prep command
+Next, if you're not running MongoDB locally, set its host configuration before running the prep command
 
 1. Determine the IP address of your MongoDB server
 2. Edit `server/config/config.dev.js` and set the following:

--- a/README.md
+++ b/README.md
@@ -59,13 +59,8 @@ ___
 
 Next set configurations before running the prep command
 
-1. Determine the IP address of your machine (Don't use localhost)
-2. Determine the IP address of your MongoDB server
-3. Edit `client/config/config.js` and set the following:
-    - `authApi => baseUrl: 'http://yourIP:8050'`
-    - `webApi => baseUrl: 'http://yourIP:8050/api/'`
-4. Edit `server/config/config.dev.js` and set the following:
-    - `config.host = 'yourIP`
+1. Determine the IP address of your MongoDB server
+2. Edit `server/config/config.dev.js` and set the following:
     - `config.mongo.connectionstring = 'mongodb://yourMongoServerIP/Applewood'`
 
 Enter `npm run prep` in the terminal open at the root of the project.

--- a/client/config/config.js
+++ b/client/config/config.js
@@ -1,7 +1,7 @@
 export default
 {
     authApi: {
-        baseUrl: 'http://192.168.1.6:8050/',
+        baseUrl: 'http://0.0.0.0:8050/',
         tokenPrefix: 'Applewood',
         tokenName: 'token',
         signupUrl: '',
@@ -17,9 +17,9 @@ export default
         'fr'
     ],
     webApi: {
-        baseUrl: 'http://192.168.1.6:8050/api/'
+        baseUrl: 'http://0.0.0.0:8050/api/'
     },
-    defaultFormats : {
+    defaultFormats: {
         date: 'MMM DD YYYY',
         number: '$0,0.00'
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.9'
+
+services:
+  mongo:
+    image: mongo
+    ports:
+      - 27017:27017

--- a/server/config/config.dev.js
+++ b/server/config/config.dev.js
@@ -5,12 +5,12 @@ config.env = "dev";
 //todo: add credentials - private key and cert for https server
 
 config.protocol = 'http';       //valid values are 'http' and 'https'
-config.host = '192.168.1.6';   //use IP and not 'localhost'
-config.port = 8050;  
+config.host = '0.0.0.0';
+config.port = 8050;
 
-config.mongo.connectionstring = 'mongodb://mongo/Applewood';
+config.mongo.connectionstring = 'mongodb://0.0.0.0/Applewood';
 
-// NOTE: generate a unique auth key for every application and environemnt
+// NOTE: generate a unique auth key for every application and environment
 config.authKey = 'VsSx9yyoUb1XhSTUTOyaZ6fyIfkAL/qVl/XIC91tryvxtRNy+9ccfpCiqnhalL4yNnMDFY9O2ja2XdrOW4quvL/FeVAviTza7IK1XVY5jAfUioG6z4Lo9bsYFyfdxWyrYSmuv6PuXIfo1iTERIFlUSeTML/kHyV27TEfg0hwzYCWayo/83qpldFaDXEX9mE47ToHw0LqyjCTxA5ufYaaLI4z0hsN5LJwKUESYsHD4niU4AVmkgimXMa+19l5oZeqmp8QRNO9m335lwum6yNz/6OsJAVraI8oyHMKAZ1aamrGKh+0jBsywIvatu/rmgLJlJBtgLqHXjkilSy94py7+Q==';
 
 module.exports = config;


### PR DESCRIPTION
First off, great work on this project! As a first time user, it came together pretty quickly and I'm looking forward to digging in further.

I did notice a couple spots where I think the initial setup/dev process could be simplified. I'm curious for your thoughts.

### 1. bind server to 0.0.0.0 by default

Rather than making users track down their local IP to bind the node server to, you can just have it bind to 0.0.0.0. This is a bit better for people who might be moving around, or who otherwise have pretty dynamic IPs. Effectively, this will bind the server to any IP that points to the machine.

### 2. provide an (optional) docker setup for running mongodb

With a docker engine installed, running `docker-compose up` will run mongo on it's default port locally (and of course, pull the image on the first run if it isn't already pulled).

This doesn't remove the option of running mongo in any other way that people might be running it already, via a manual install or on some remote box. I did, however, point the dev config at 0.0.0.0 as the mongo host. This should work for anyone running mongo locally, via docker or otherwise.

Feel free to slap me for not making this two separate PRs. I can split them out if that's the preference around these parts.